### PR TITLE
Add Halo 2 notes on prioritization and packet managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Networking for the Game Halo Franchise
 - [GDC Session Summary: Halo Networking](https://www.wolfire.com/blog/2011/03/GDC-Session-Summary-Halo-networking/)
 - [A Traffic Model for the Xbox Game Halo 2](https://www.wolfire.com/blog/2011/03/GDC-Session-Summary-Halo-networking/)
 - [Running the Halo Multiplayer Experience at 60fps: A Technical Art Perspective](https://www.youtube.com/watch?v=65_lBJbAxnk)
+- [Halo 2 Networking Notes: Prioritization vs. Packetization](docs/networking/halo2_prioritization_packet_manager.md)
 
 Networking for the Half Life Franchise
 - [Latency Compensating Methods in Client/Server In-game Protocol Design and Optimization](https://www.gamedevs.org/uploads/latency-compensation-in-client-server-protocols.pdf?)

--- a/docs/networking/halo2_prioritization_packet_manager.md
+++ b/docs/networking/halo2_prioritization_packet_manager.md
@@ -1,0 +1,35 @@
+# Halo 2 Networking Notes: Prioritization vs. Packetization
+
+The Halo 2 postmortems emphasize maintaining two distinct responsibilities inside the networking stack:
+
+- **PrioritizationManager** picks which entities and state channels deserve bandwidth each tick.
+- **PacketManager** serializes those chosen states into network frames, manages reliable/unreliable channels, and submits them to the transport.
+
+Keeping these roles separated prevents priority heuristics from knowing about transport internals while letting packet assembly swap between ENet, custom UDP, or future transports.
+
+## Responsibilities
+
+### PrioritizationManager
+- Maintain per-client visibility buckets, distance and relevance scores.
+- Track last-sent tick per entity/component so deltas are scheduled only when their priority score clears a configurable threshold.
+- Hand back an ordered list of `ReplicationRequest { entity_id, component_mask, priority, desired_budget_bytes }`.
+- Persist priority state (decay, boosts) independently of packetization cadence, so changing MTU or transport framing does not skew scheduling decisions.
+
+### PacketManager
+- Consume the ordered replication requests and slice them into packets respecting MTU, channel reliability, and QoS constraints.
+- Perform delta compression/bit-packing and attach baselines/acks as required by the transport.
+- Defer to `MultiplayerAPI`/ENet for delivery but expose hooks for bandwidth accounting and telemetry.
+- Issue callbacks when requests are dropped due to budget exhaustion so the prioritizer can react (e.g., boost an entity next tick).
+
+## Interaction Flow
+1. Server tick calls `PrioritizationManager::gather(client_id, tick)` to obtain prioritized replication requests.
+2. The ordered requests are fed into `PacketManager::write_packets(client_id, requests, tick)`.
+3. Packet manager emits one or more transport frames, tracking ack baselines separately.
+4. If packetization cannot fit a request, it notifies the prioritizer with the drop context so the next gather can react.
+
+## Alignment with Tribes-Inspired Plan
+- The Phase 2 work item "Implement Tribes-style prioritized replication" should instantiate the **PrioritizationManager** described above and keep it independent from delta encoding logic.
+- Delta compression and client baseline bookkeeping sit inside the **PacketManager**, aligning with Halo 2's split between scheduling and encoding.
+- This layout makes it easier to add Halo-style "channel budgets" or to experiment with different transports without perturbing prioritization heuristics.
+
+Keeping the boundary explicit gives us room to experiment with Halo 2's interest management tricks (e.g., priority decay, threat boosts) while letting the packetizer evolve alongside transport upgrades.


### PR DESCRIPTION
## Summary
- add an internal note capturing the Halo 2-inspired separation of prioritization and packet managers
- link the new document from the Halo franchise inspiration list in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9238863c83249848e02374b30ad3