### PR TITLE
Implement LAN discovery and manual join sprint tasks

### DIFF
--- a/room_sync/network/DiscoveryBeacon.gd
+++ b/room_sync/network/DiscoveryBeacon.gd
@@ -1,0 +1,109 @@
+extends Node
+
+## Emits a periodic LAN discovery broadcast with throttling to avoid flooding.
+signal beacon_sent(sequence_number: int)
+signal beacon_skipped(reason: String)
+
+@export var broadcast_port: int = 47845
+@export var broadcast_addresses: PackedStringArray = ["255.255.255.255"]
+@export var throttle_window_seconds: float = 5.0
+@export var max_packets_per_window: int = 5
+@export var payload: Dictionary = {
+    "protocol": "room_sync",
+    "version": "0.1.0"
+}
+@export var autostart: bool = false
+@export_range(0.1, 10.0, 0.1, "or_greater") var broadcast_interval_seconds: float = 1.5:
+    set(value):
+        set_broadcast_interval(value)
+    get:
+        return get_broadcast_interval()
+
+var _broadcast_interval: float = 1.5
+
+var _udp := PacketPeerUDP.new()
+var _timer := Timer.new()
+var _window_start_time := 0.0
+var _sent_in_window := 0
+var _sequence := 0
+var _active := false
+
+func _ready() -> void:
+    add_child(_timer)
+    _timer.wait_time = _broadcast_interval
+    _timer.one_shot = false
+    _timer.timeout.connect(_on_timer_timeout)
+    if autostart and not Engine.is_editor_hint():
+        start()
+
+func start() -> void:
+    if _active:
+        return
+    _active = true
+    _prepare_socket()
+    _reset_window(Time.get_ticks_msec() / 1000.0)
+    _timer.start()
+
+func stop() -> void:
+    if not _active:
+        return
+    _active = false
+    _timer.stop()
+    _udp.close()
+
+func set_payload(data: Dictionary) -> void:
+    payload = data.duplicate(true)
+
+func set_broadcast_interval(seconds: float) -> void:
+    _broadcast_interval = max(seconds, 0.1)
+    if is_instance_valid(_timer):
+        _timer.wait_time = _broadcast_interval
+
+func get_broadcast_interval() -> float:
+    return _broadcast_interval
+
+func _prepare_socket() -> void:
+    _udp = PacketPeerUDP.new()
+    _udp.set_broadcast_enabled(true)
+
+func _on_timer_timeout() -> void:
+    if not _active:
+        return
+    var now := Time.get_ticks_msec() / 1000.0
+    if now - _window_start_time >= throttle_window_seconds:
+        _reset_window(now)
+    if _sent_in_window >= max_packets_per_window:
+        beacon_skipped.emit("throttled")
+        return
+    _send_beacon()
+
+func _reset_window(now_seconds: float) -> void:
+    _window_start_time = now_seconds
+    _sent_in_window = 0
+
+func _send_beacon() -> void:
+    var serialized := JSON.stringify(_build_payload()).to_utf8_buffer()
+    if broadcast_addresses.is_empty():
+        beacon_skipped.emit("no_addresses")
+        return
+    var sent := false
+    for address in broadcast_addresses:
+        var err := _udp.set_dest_address(address, broadcast_port)
+        if err != OK:
+            beacon_skipped.emit("set_dest_failed:%s" % address)
+            continue
+        err = _udp.put_packet(serialized)
+        if err == OK:
+            sent = true
+        else:
+            beacon_skipped.emit("send_failed:%s" % address)
+    if sent:
+        _sent_in_window += 1
+        _sequence += 1
+        beacon_sent.emit(_sequence)
+
+func _build_payload() -> Dictionary:
+    var result := payload.duplicate(true)
+    result["timestamp"] = Time.get_ticks_msec()
+    result["sequence"] = _sequence + 1
+    return result

--- a/room_sync/network/LanRoomManager.gd
+++ b/room_sync/network/LanRoomManager.gd
@@ -1,0 +1,90 @@
+extends Node
+
+## Tracks LAN room candidates and elects a host using simple heuristics.
+signal host_changed(peer_id: String, descriptor: Dictionary)
+signal roster_updated(candidates: Dictionary)
+
+@export var local_peer_id: String = ""
+@export var require_local_candidate: bool = true
+
+var _candidates: Dictionary = {}
+var _current_host_id: String = ""
+
+func set_local_peer_id(peer_id: String) -> void:
+    local_peer_id = peer_id
+    if require_local_candidate and not _candidates.has(peer_id):
+        push_warning("Local peer updated but not present in candidate list")
+
+func register_candidate(peer_id: String, descriptor: Dictionary) -> void:
+    if peer_id.is_empty():
+        push_warning("Attempted to register candidate without peer_id")
+        return
+    _candidates[peer_id] = descriptor.duplicate(true)
+    _evaluate_host()
+    roster_updated.emit(_candidates.duplicate(true))
+
+func remove_candidate(peer_id: String) -> void:
+    if not _candidates.has(peer_id):
+        return
+    _candidates.erase(peer_id)
+    _evaluate_host()
+    roster_updated.emit(_candidates.duplicate(true))
+
+func clear_candidates() -> void:
+    _candidates.clear()
+    _evaluate_host()
+    roster_updated.emit(_candidates.duplicate(true))
+
+func get_current_host_id() -> String:
+    return _current_host_id
+
+func get_candidate(peer_id: String) -> Dictionary:
+    return _candidates.get(peer_id, {}).duplicate(true)
+
+func _evaluate_host() -> void:
+    if _candidates.is_empty():
+        _set_host("")
+        return
+    var ranked := []
+    for peer_id in _candidates.keys():
+        var descriptor: Dictionary = _candidates[peer_id]
+        ranked.append({
+            "peer_id": peer_id,
+            "score": _score_candidate(peer_id, descriptor),
+            "latency": descriptor.get("latency_ms", 0.0)
+        })
+    ranked.sort_custom(func(a, b):
+        if a.score == b.score:
+            if a.latency == b.latency:
+                return a.peer_id < b.peer_id
+            return a.latency < b.latency
+        return a.score > b.score
+    )
+    var best := ranked.front()
+    if require_local_candidate and not _candidates.has(local_peer_id):
+        push_warning("Local peer is not registered; host election may be stale")
+    _set_host(best.peer_id)
+
+func _score_candidate(peer_id: String, descriptor: Dictionary) -> float:
+    var performance := float(descriptor.get("performance_score", 0.0))
+    var battery := float(descriptor.get("battery_level", 0.0))
+    var latency := float(descriptor.get("latency_ms", 0.0))
+    var favors_local := peer_id == local_peer_id ? 5.0 : 0.0
+    # Placeholder heuristic:
+    # - prioritize higher performance and battery
+    # - penalize latency modestly
+    # - nudge toward the local peer if scores tie to speed up testing
+    return (performance * 0.6) + (battery * 0.3) - (latency * 0.1) + favors_local
+
+func _set_host(peer_id: String) -> void:
+    if _current_host_id == peer_id:
+        return
+    _current_host_id = peer_id
+    var descriptor := _candidates.get(peer_id, {}).duplicate(true)
+    host_changed.emit(peer_id, descriptor)
+
+func snapshot_room() -> Dictionary:
+    return {
+        "host_id": _current_host_id,
+        "candidates": _candidates.duplicate(true)
+    }

--- a/room_sync/ui/ManualJoinPanel.gd
+++ b/room_sync/ui/ManualJoinPanel.gd
@@ -1,0 +1,133 @@
+extends Panel
+
+## Collects manual connection details and validates address + port input.
+signal join_requested(address: String, port: int)
+signal dismissed()
+
+@export var default_port: int = 47845
+@export var room_code_min_length: int = 4
+@export var room_code_max_length: int = 8
+
+@onready var _ip_input: LineEdit = %IpLineEdit
+@onready var _port_input: LineEdit = %PortLineEdit
+@onready var _join_button: Button = %JoinButton
+@onready var _cancel_button: Button = %CancelButton
+@onready var _error_label: Label = %ErrorLabel
+
+var _busy := false
+
+func _ready() -> void:
+    _ip_input.text_changed.connect(_on_input_changed)
+    _port_input.text_changed.connect(_on_input_changed)
+    _join_button.pressed.connect(_on_join_pressed)
+    _cancel_button.pressed.connect(func():
+        reset_form()
+        hide()
+        dismissed.emit()
+    )
+    _error_label.visible = false
+    _error_label.text = ""
+    reset_form(_ip_input.text, default_port)
+
+func focus_ip() -> void:
+    _ip_input.grab_focus()
+
+func reset_form(address: String = "", port: int = default_port) -> void:
+    _busy = false
+    _cancel_button.disabled = false
+    _ip_input.editable = true
+    _port_input.editable = true
+    _ip_input.text = address.strip_edges()
+    _port_input.text = str(port)
+    _error_label.text = ""
+    _error_label.visible = false
+    _update_state()
+
+func set_busy(is_busy: bool) -> void:
+    _busy = is_busy
+    _cancel_button.disabled = is_busy
+    _ip_input.editable = not is_busy
+    _port_input.editable = not is_busy
+    _update_state()
+
+func _on_join_pressed() -> void:
+    if _busy:
+        return
+    var address := _ip_input.text.strip_edges()
+    var port_text := _port_input.text.strip_edges()
+    var validation := _validate(address, port_text)
+    if validation["ok"]:
+        _error_label.visible = false
+        _error_label.text = ""
+        var port := int(port_text)
+        emit_signal("join_requested", address, port)
+    else:
+        _error_label.text = validation["error"]
+        _error_label.visible = true
+
+func _on_input_changed(_text: String) -> void:
+    _update_state()
+
+func _update_state() -> void:
+    var address := _ip_input.text.strip_edges()
+    var port_text := _port_input.text.strip_edges()
+    var validation := _validate(address, port_text)
+    _join_button.disabled = _busy or not validation["ok"]
+    if validation["ok"]:
+        _error_label.text = ""
+        _error_label.visible = false
+    elif not _error_label.text.is_empty():
+        _error_label.visible = true
+
+func _validate(address: String, port_text: String) -> Dictionary:
+    if address.is_empty():
+        return {"ok": false, "error": "Enter an address or room code."}
+    var port_valid := _is_valid_port(port_text)
+    var address_valid := _is_valid_ipv4(address) or _is_valid_hostname(address) or _is_valid_room_code(address)
+    if not port_valid:
+        return {"ok": false, "error": "Port must be between 1 and 65535."}
+    if not address_valid:
+        return {"ok": false, "error": "Use a valid IPv4, hostname, or room code."}
+    return {"ok": true}
+
+func _is_valid_port(value: String) -> bool:
+    if value.is_empty() or not value.is_valid_int():
+        return false
+    var number := int(value)
+    return number > 0 and number < 65536
+
+func _is_valid_ipv4(address: String) -> bool:
+    var segments := address.split(".", false)
+    if segments.size() != 4:
+        return false
+    for segment in segments:
+        if segment.is_empty() or not segment.is_valid_int():
+            return false
+        var number := int(segment)
+        if number < 0 or number > 255:
+            return false
+    return true
+
+func _is_valid_hostname(address: String) -> bool:
+    if address.length() > 253:
+        return false
+    var allowed := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-."
+    for char in address:
+        if not allowed.contains(char):
+            return false
+    if address.begins_with("-") or address.ends_with("-"):
+        return false
+    return true
+
+func _is_valid_room_code(address: String) -> bool:
+    if address.is_empty():
+        return false
+    var upper := address.strip_edges().to_upper()
+    if upper.length() < room_code_min_length or upper.length() > room_code_max_length:
+        return false
+    for char in upper:
+        var is_letter := char >= "A" and char <= "Z"
+        var is_number := char >= "0" and char <= "9"
+        if not (is_letter or is_number):
+            return false
+    return true

--- a/room_sync/ui/ManualJoinPanel.tscn
+++ b/room_sync/ui/ManualJoinPanel.tscn
@@ -1,0 +1,68 @@
+[gd_scene load_steps=2 format=3 uid="uid://manualjoinpanel"]
+
+[ext_resource type="Script" path="res://ui/ManualJoinPanel.gd" id="1_jt8oi"]
+
+[node name="ManualJoinPanel" type="Panel"]
+custom_minimum_size = Vector2(360, 220)
+clip_contents = false
+script = ExtResource("1_jt8oi")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 16.0
+offset_top = 16.0
+offset_right = -16.0
+offset_bottom = -16.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="VBox" type="VBoxContainer" parent="MarginContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 12
+
+[node name="TitleLabel" type="Label" parent="MarginContainer/VBox"]
+text = "Manual Join"
+vertical_alignment = 1
+
+[node name="Instructions" type="Label" parent="MarginContainer/VBox"]
+autowrap_mode = 1
+text = "Enter an IP, hostname, or room code plus the port shared by the room owner."
+
+[node name="AddressLabel" type="Label" parent="MarginContainer/VBox"]
+text = "Address"
+
+[node name="IpLineEdit" type="LineEdit" parent="MarginContainer/VBox"]
+placeholder_text = "192.168.0.24, room.local, or CODE123"
+text = ""
+
+[node name="PortLabel" type="Label" parent="MarginContainer/VBox"]
+text = "Port"
+
+[node name="PortLineEdit" type="LineEdit" parent="MarginContainer/VBox"]
+placeholder_text = "47845"
+virtual_keyboard_type = 2
+text = ""
+
+[node name="ErrorLabel" type="Label" parent="MarginContainer/VBox"]
+visible = false
+modulate = Color(1, 0.356863, 0.356863, 1)
+autowrap_mode = 1
+text = ""
+
+[node name="Buttons" type="HBoxContainer" parent="MarginContainer/VBox"]
+alignment = 2
+
+[node name="CancelButton" type="Button" parent="MarginContainer/VBox/Buttons"]
+text = "Cancel"
+size_flags_horizontal = 1
+
+[node name="JoinButton" type="Button" parent="MarginContainer/VBox/Buttons"]
+text = "Join"
+size_flags_horizontal = 1
+disabled = true


### PR DESCRIPTION
## Summary
- add a DiscoveryBeacon node that emits throttled LAN broadcast beacons with configurable payloads
- add a LanRoomManager that ranks candidates and elects a host using placeholder performance heuristics
- create a ManualJoinPanel UI with validation and reset helpers for IP, hostname, or room code entries

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb39ebc3883249799e03b7a7458e3