### PR TITLE
Add automated Godot LAN discovery and join tests

### DIFF
--- a/room_sync/network/DiscoveryBeacon.gd
+++ b/room_sync/network/DiscoveryBeacon.gd
@@ -1,0 +1,132 @@
+class_name DiscoveryBeacon
+extends Node
+
+## Emits a periodic LAN discovery broadcast with throttling to avoid flooding.
+signal beacon_sent(sequence_number: int)
+signal beacon_skipped(reason: String)
+
+@export var broadcast_port: int = 47845
+@export var broadcast_addresses: PackedStringArray = ["255.255.255.255"]
+@export var throttle_window_seconds: float = 5.0
+@export var max_packets_per_window: int = 5
+@export var payload: Dictionary = {
+    "protocol": "room_sync",
+    "version": "0.1.0"
+}
+@export var autostart: bool = false
+@export_range(0.1, 10.0, 0.1, "or_greater") var broadcast_interval_seconds: float = 1.5:
+    set(value):
+        set_broadcast_interval(value)
+    get:
+        return get_broadcast_interval()
+
+var _broadcast_interval: float = 1.5
+
+var _udp_factory: Callable = func():
+    return PacketPeerUDP.new()
+
+var _udp: Object = null
+var _timer := Timer.new()
+var _window_start_time := 0.0
+var _sent_in_window := 0
+var _sequence := 0
+var _active := false
+
+func _ready() -> void:
+    add_child(_timer)
+    _timer.wait_time = _broadcast_interval
+    _timer.one_shot = false
+    _timer.timeout.connect(_on_timer_timeout)
+    if autostart and not Engine.is_editor_hint():
+        start()
+
+func start() -> void:
+    if _active:
+        return
+    _active = true
+    _prepare_socket()
+    _reset_window(Time.get_ticks_msec() / 1000.0)
+    _timer.start()
+
+func stop() -> void:
+    if not _active:
+        return
+    _active = false
+    _timer.stop()
+    if _udp and _udp.has_method("close"):
+        _udp.close()
+    _udp = null
+
+func set_payload(data: Dictionary) -> void:
+    payload = data.duplicate(true)
+
+func set_broadcast_interval(seconds: float) -> void:
+    _broadcast_interval = max(seconds, 0.1)
+    if is_instance_valid(_timer):
+        _timer.wait_time = _broadcast_interval
+
+func get_broadcast_interval() -> float:
+    return _broadcast_interval
+
+func set_udp_factory(factory: Callable) -> void:
+    if factory and factory.is_valid():
+        _udp_factory = factory
+    else:
+        _udp_factory = func():
+            return PacketPeerUDP.new()
+
+func get_udp_peer() -> Object:
+    return _udp
+
+func _prepare_socket() -> void:
+    _udp = _udp_factory.call()
+    if _udp == null:
+        push_warning("UDP factory returned null; falling back to PacketPeerUDP")
+        _udp = PacketPeerUDP.new()
+    if _udp.has_method("set_broadcast_enabled"):
+        _udp.set_broadcast_enabled(true)
+
+func _on_timer_timeout() -> void:
+    if not _active:
+        return
+    var now := Time.get_ticks_msec() / 1000.0
+    if now - _window_start_time >= throttle_window_seconds:
+        _reset_window(now)
+    if _sent_in_window >= max_packets_per_window:
+        beacon_skipped.emit("throttled")
+        return
+    _send_beacon()
+
+func _reset_window(now_seconds: float) -> void:
+    _window_start_time = now_seconds
+    _sent_in_window = 0
+
+func _send_beacon() -> void:
+    if _udp == null:
+        beacon_skipped.emit("no_socket")
+        return
+    var serialized := JSON.stringify(_build_payload()).to_utf8_buffer()
+    if broadcast_addresses.is_empty():
+        beacon_skipped.emit("no_addresses")
+        return
+    var sent := false
+    for address in broadcast_addresses:
+        var err := _udp.set_dest_address(address, broadcast_port)
+        if err != OK:
+            beacon_skipped.emit("set_dest_failed:%s" % address)
+            continue
+        err = _udp.put_packet(serialized)
+        if err == OK:
+            sent = true
+        else:
+            beacon_skipped.emit("send_failed:%s" % address)
+    if sent:
+        _sent_in_window += 1
+        _sequence += 1
+        beacon_sent.emit(_sequence)
+
+func _build_payload() -> Dictionary:
+    var result := payload.duplicate(true)
+    result["timestamp"] = Time.get_ticks_msec()
+    result["sequence"] = _sequence + 1
+    return result

--- a/room_sync/network/LanRoomManager.gd
+++ b/room_sync/network/LanRoomManager.gd
@@ -1,0 +1,91 @@
+class_name LanRoomManager
+extends Node
+
+## Tracks LAN room candidates and elects a host using simple heuristics.
+signal host_changed(peer_id: String, descriptor: Dictionary)
+signal roster_updated(candidates: Dictionary)
+
+@export var local_peer_id: String = ""
+@export var require_local_candidate: bool = true
+
+var _candidates: Dictionary = {}
+var _current_host_id: String = ""
+
+func set_local_peer_id(peer_id: String) -> void:
+    local_peer_id = peer_id
+    if require_local_candidate and not _candidates.has(peer_id):
+        push_warning("Local peer updated but not present in candidate list")
+
+func register_candidate(peer_id: String, descriptor: Dictionary) -> void:
+    if peer_id.is_empty():
+        push_warning("Attempted to register candidate without peer_id")
+        return
+    _candidates[peer_id] = descriptor.duplicate(true)
+    _evaluate_host()
+    roster_updated.emit(_candidates.duplicate(true))
+
+func remove_candidate(peer_id: String) -> void:
+    if not _candidates.has(peer_id):
+        return
+    _candidates.erase(peer_id)
+    _evaluate_host()
+    roster_updated.emit(_candidates.duplicate(true))
+
+func clear_candidates() -> void:
+    _candidates.clear()
+    _evaluate_host()
+    roster_updated.emit(_candidates.duplicate(true))
+
+func get_current_host_id() -> String:
+    return _current_host_id
+
+func get_candidate(peer_id: String) -> Dictionary:
+    return _candidates.get(peer_id, {}).duplicate(true)
+
+func _evaluate_host() -> void:
+    if _candidates.is_empty():
+        _set_host("")
+        return
+    var ranked := []
+    for peer_id in _candidates.keys():
+        var descriptor: Dictionary = _candidates[peer_id]
+        ranked.append({
+            "peer_id": peer_id,
+            "score": _score_candidate(peer_id, descriptor),
+            "latency": descriptor.get("latency_ms", 0.0)
+        })
+    ranked.sort_custom(func(a, b):
+        if a.score == b.score:
+            if a.latency == b.latency:
+                return a.peer_id < b.peer_id
+            return a.latency < b.latency
+        return a.score > b.score
+    )
+    var best := ranked.front()
+    if require_local_candidate and not _candidates.has(local_peer_id):
+        push_warning("Local peer is not registered; host election may be stale")
+    _set_host(best.peer_id)
+
+func _score_candidate(peer_id: String, descriptor: Dictionary) -> float:
+    var performance := float(descriptor.get("performance_score", 0.0))
+    var battery := float(descriptor.get("battery_level", 0.0))
+    var latency := float(descriptor.get("latency_ms", 0.0))
+    var favors_local := peer_id == local_peer_id ? 5.0 : 0.0
+    # Placeholder heuristic:
+    # - prioritize higher performance and battery
+    # - penalize latency modestly
+    # - nudge toward the local peer if scores tie to speed up testing
+    return (performance * 0.6) + (battery * 0.3) - (latency * 0.1) + favors_local
+
+func _set_host(peer_id: String) -> void:
+    if _current_host_id == peer_id:
+        return
+    _current_host_id = peer_id
+    var descriptor := _candidates.get(peer_id, {}).duplicate(true)
+    host_changed.emit(peer_id, descriptor)
+
+func snapshot_room() -> Dictionary:
+    return {
+        "host_id": _current_host_id,
+        "candidates": _candidates.duplicate(true)
+    }

--- a/room_sync/tests/test_runner.gd
+++ b/room_sync/tests/test_runner.gd
@@ -1,0 +1,283 @@
+extends SceneTree
+
+var _current_test_passed := true
+var _tests_run := 0
+var _tests_failed := 0
+
+class MockPacketPeerUDP:
+    var destinations: Array = []
+    var payloads: Array = []
+    var dest_failures: Dictionary = {}
+    var send_failures: Dictionary = {}
+    var broadcast_enabled := false
+    var closed := false
+    var _current_address := ""
+    var ports: Array = []
+
+    func set_broadcast_enabled(enabled: bool) -> void:
+        broadcast_enabled = enabled
+
+    func set_dest_address(address: String, port: int) -> int:
+        _current_address = address
+        if dest_failures.has(address):
+            return dest_failures[address]
+        destinations.append({"address": address, "port": port})
+        ports.append(port)
+        return OK
+
+    func put_packet(packet: PackedByteArray) -> int:
+        if send_failures.has(_current_address):
+            return send_failures[_current_address]
+        payloads.append({"address": _current_address, "data": packet})
+        return OK
+
+    func close() -> void:
+        closed = true
+
+func _initialize() -> void:
+    call_deferred("_run_tests")
+
+func _run_tests() -> void:
+    var tests := [
+        "test_discovery_single_host",
+        "test_discovery_multiple_hosts",
+        "test_discovery_blocked_broadcast",
+        "test_lan_manager_serialization_round_trip",
+        "test_manual_join_integration_flow",
+    ]
+
+    for name in tests:
+        _current_test_passed = true
+        _tests_run += 1
+        var state = self.call(name)
+        if state is GDScriptFunctionState:
+            await state
+        if _current_test_passed:
+            print("[PASS] %s" % name)
+        else:
+            _tests_failed += 1
+            print("[FAIL] %s" % name)
+
+    print("Tests passed: %d/%d" % [_tests_run - _tests_failed, _tests_run])
+    quit(_tests_failed)
+
+func _assert(condition: bool, message: String = "") -> bool:
+    if condition:
+        return true
+    _current_test_passed = false
+    push_error(message if not message.is_empty() else "Assertion failed")
+    return false
+
+func _create_beacon() -> DiscoveryBeacon:
+    var beacon := DiscoveryBeacon.new()
+    get_root().add_child(beacon)
+    await beacon.ready
+    beacon.autostart = false
+    beacon.max_packets_per_window = 10
+    beacon.throttle_window_seconds = 1.0
+    return beacon
+
+func _teardown_node(node: Node) -> void:
+    if node and node.get_parent():
+        node.queue_free()
+        await get_tree().process_frame
+
+func test_discovery_single_host() -> void:
+    var beacon := await _create_beacon()
+    var mock_peer := MockPacketPeerUDP.new()
+    beacon.set_udp_factory(func():
+        return mock_peer
+    )
+    beacon.broadcast_addresses = ["192.168.1.255"]
+    var sent_sequences := []
+    var skipped := []
+    beacon.beacon_sent.connect(func(sequence): sent_sequences.append(sequence))
+    beacon.beacon_skipped.connect(func(reason): skipped.append(reason))
+    beacon.start()
+    beacon._on_timer_timeout()
+
+    _assert(mock_peer.broadcast_enabled, "Broadcast flag should be enabled on UDP socket")
+    _assert(mock_peer.payloads.size() == 1, "Expected a single payload to be sent")
+    _assert(sent_sequences == [1], "Sequence should increment to 1 after first send")
+    _assert(skipped.is_empty(), "No skips expected for successful send")
+
+    beacon.stop()
+    await _teardown_node(beacon)
+
+func test_discovery_multiple_hosts() -> void:
+    var beacon := await _create_beacon()
+    var mock_peer := MockPacketPeerUDP.new()
+    beacon.set_udp_factory(func():
+        return mock_peer
+    )
+    beacon.broadcast_addresses = ["192.168.1.255", "10.0.0.255"]
+    var sent_sequences := []
+    beacon.beacon_sent.connect(func(sequence): sent_sequences.append(sequence))
+    beacon.start()
+    beacon._on_timer_timeout()
+
+    _assert(mock_peer.payloads.size() == 2, "Should send a payload for each destination")
+    _assert(sent_sequences == [1], "Sequence should still only advance once per interval")
+    _assert(mock_peer.destinations.size() == 2, "Both destinations should be attempted")
+
+    beacon.stop()
+    await _teardown_node(beacon)
+
+func test_discovery_blocked_broadcast() -> void:
+    var beacon := await _create_beacon()
+    var mock_peer := MockPacketPeerUDP.new()
+    mock_peer.dest_failures["255.255.255.255"] = ERR_UNAVAILABLE
+    beacon.set_udp_factory(func():
+        return mock_peer
+    )
+    beacon.broadcast_addresses = ["255.255.255.255"]
+    var skipped := []
+    beacon.beacon_skipped.connect(func(reason): skipped.append(reason))
+    beacon.start()
+    beacon._on_timer_timeout()
+
+    _assert(mock_peer.payloads.is_empty(), "No payloads should be recorded when broadcast is blocked")
+    _assert(skipped.has("set_dest_failed:255.255.255.255"), "Blocked broadcast should surface failure reason")
+
+    beacon.stop()
+    await _teardown_node(beacon)
+
+func test_lan_manager_serialization_round_trip() -> void:
+    var manager := LanRoomManager.new()
+    get_root().add_child(manager)
+    await manager.ready
+    manager.require_local_candidate = false
+    manager.set_local_peer_id("peer_alpha")
+
+    var descriptor_alpha := {
+        "performance_score": 9.5,
+        "battery_level": 0.9,
+        "latency_ms": 40.0,
+        "session": {
+            "id": "session-123",
+            "version": "1.2.0",
+            "peers": ["peer_alpha"]
+        },
+        "peer_id": "peer_alpha"
+    }
+    var descriptor_beta := {
+        "performance_score": 8.0,
+        "battery_level": 0.8,
+        "latency_ms": 35.0,
+        "session": {
+            "id": "session-123",
+            "version": "1.2.0",
+            "peers": ["peer_alpha", "peer_beta"]
+        },
+        "peer_id": "peer_beta"
+    }
+
+    manager.register_candidate("peer_alpha", descriptor_alpha)
+    manager.register_candidate("peer_beta", descriptor_beta)
+
+    var snapshot := manager.snapshot_room()
+    var json := JSON.stringify(snapshot)
+    var parsed := JSON.parse_string(json)
+
+    _assert(parsed is Dictionary, "Snapshot should decode to a dictionary")
+    _assert(parsed["host_id"] == manager.get_current_host_id(), "Host id should survive serialization round-trip")
+    _assert(parsed["candidates"].has("peer_alpha"), "Alpha candidate should persist")
+    _assert(parsed["candidates"]["peer_beta"]["session"]["peers"].has("peer_beta"), "Peer roster should serialize correctly")
+
+    parsed["candidates"]["peer_alpha"]["session"]["id"] = "mutated"
+    _assert(manager.get_candidate("peer_alpha")["session"]["id"] == "session-123", "Original descriptor should remain unchanged after mutation")
+
+    await _teardown_node(manager)
+
+func test_manual_join_integration_flow() -> void:
+    var host_manager := LanRoomManager.new()
+    host_manager.require_local_candidate = false
+    host_manager.set_local_peer_id("host")
+    get_root().add_child(host_manager)
+    await host_manager.ready
+
+    var guest_manager := LanRoomManager.new()
+    guest_manager.require_local_candidate = false
+    guest_manager.set_local_peer_id("guest")
+    get_root().add_child(guest_manager)
+    await guest_manager.ready
+
+    var host_descriptor := {
+        "performance_score": 10.0,
+        "battery_level": 1.0,
+        "latency_ms": 10.0,
+        "session": {
+            "id": "room-xyz",
+            "version": "1.0",
+            "peers": ["host"]
+        },
+        "peer_id": "host"
+    }
+    host_manager.register_candidate("host", host_descriptor)
+
+    var panel_scene: PackedScene = load("res://ui/ManualJoinPanel.tscn")
+    var panel: ManualJoinPanel = panel_scene.instantiate()
+    get_root().add_child(panel)
+    await panel.ready
+
+    var ip_field: LineEdit = panel.get_node("%IpLineEdit")
+    var port_field: LineEdit = panel.get_node("%PortLineEdit")
+    var join_button: Button = panel.get_node("%JoinButton")
+    var error_label: Label = panel.get_node("%ErrorLabel")
+
+    panel.reset_form("", panel.default_port)
+
+    ip_field.text = ""
+    port_field.text = ""
+    panel.call("_on_join_pressed")
+    await get_tree().process_frame
+
+    _assert(error_label.visible, "Error label should display when join validation fails")
+    _assert(error_label.text.find("Enter an address") != -1, "Empty address should surface guidance")
+
+    panel.reset_form("", panel.default_port)
+    var join_events: Array = []
+    panel.join_requested.connect(func(address: String, port: int):
+        join_events.append({"address": address, "port": port})
+        if address == "192.168.0.10":
+            var guest_descriptor := {
+                "performance_score": 7.5,
+                "battery_level": 0.9,
+                "latency_ms": 25.0,
+                "session": {
+                    "id": "room-xyz",
+                    "version": "1.0",
+                    "peers": ["host", "guest"]
+                },
+                "peer_id": "guest"
+            }
+            host_manager.register_candidate("guest", guest_descriptor)
+            guest_manager.register_candidate("host", host_descriptor)
+        else:
+            panel.set_busy(false)
+            panel.show_error("Room unavailable")
+    )
+
+    ip_field.text = "192.168.0.10"
+    port_field.text = "47845"
+    panel.call("_update_state")
+    _assert(not join_button.disabled, "Join button should enable for valid IPv4 input")
+    panel.call("_on_join_pressed")
+    await get_tree().process_frame
+
+    _assert(join_events.size() == 1, "Successful submission should emit join_requested")
+    _assert(host_manager.get_candidate("guest").get("peer_id", "") == "guest", "Guest descriptor should register with host manager")
+
+    ip_field.text = "ROOM1"
+    port_field.text = str(panel.default_port)
+    panel.call("_update_state")
+    panel.call("_on_join_pressed")
+    await get_tree().process_frame
+
+    _assert(join_events.size() == 2, "Second submission should still emit join_requested")
+    _assert(error_label.text == "Room unavailable", "Rejected join should report error from integration harness")
+    _assert(error_label.visible, "Rejected join should surface error label")
+
+    await _teardown_node(panel)
+    await _teardown_node(host_manager)
+    await _teardown_node(guest_manager)

--- a/room_sync/ui/ManualJoinPanel.gd
+++ b/room_sync/ui/ManualJoinPanel.gd
@@ -1,0 +1,138 @@
+class_name ManualJoinPanel
+extends Panel
+
+## Collects manual connection details and validates address + port input.
+signal join_requested(address: String, port: int)
+signal dismissed()
+
+@export var default_port: int = 47845
+@export var room_code_min_length: int = 4
+@export var room_code_max_length: int = 8
+
+@onready var _ip_input: LineEdit = %IpLineEdit
+@onready var _port_input: LineEdit = %PortLineEdit
+@onready var _join_button: Button = %JoinButton
+@onready var _cancel_button: Button = %CancelButton
+@onready var _error_label: Label = %ErrorLabel
+
+var _busy := false
+
+func _ready() -> void:
+    _ip_input.text_changed.connect(_on_input_changed)
+    _port_input.text_changed.connect(_on_input_changed)
+    _join_button.pressed.connect(_on_join_pressed)
+    _cancel_button.pressed.connect(func():
+        reset_form()
+        hide()
+        dismissed.emit()
+    )
+    _error_label.visible = false
+    _error_label.text = ""
+    reset_form(_ip_input.text, default_port)
+
+func focus_ip() -> void:
+    _ip_input.grab_focus()
+
+func reset_form(address: String = "", port: int = default_port) -> void:
+    _busy = false
+    _cancel_button.disabled = false
+    _ip_input.editable = true
+    _port_input.editable = true
+    _ip_input.text = address.strip_edges()
+    _port_input.text = str(port)
+    _error_label.text = ""
+    _error_label.visible = false
+    _update_state()
+
+func set_busy(is_busy: bool) -> void:
+    _busy = is_busy
+    _cancel_button.disabled = is_busy
+    _ip_input.editable = not is_busy
+    _port_input.editable = not is_busy
+    _update_state()
+
+func show_error(message: String) -> void:
+    _error_label.text = message
+    _error_label.visible = not message.is_empty()
+
+func _on_join_pressed() -> void:
+    if _busy:
+        return
+    var address := _ip_input.text.strip_edges()
+    var port_text := _port_input.text.strip_edges()
+    var validation := _validate(address, port_text)
+    if validation["ok"]:
+        _error_label.visible = false
+        _error_label.text = ""
+        var port := int(port_text)
+        emit_signal("join_requested", address, port)
+    else:
+        _error_label.text = validation["error"]
+        _error_label.visible = true
+
+func _on_input_changed(_text: String) -> void:
+    _update_state()
+
+func _update_state() -> void:
+    var address := _ip_input.text.strip_edges()
+    var port_text := _port_input.text.strip_edges()
+    var validation := _validate(address, port_text)
+    _join_button.disabled = _busy or not validation["ok"]
+    if validation["ok"]:
+        _error_label.text = ""
+        _error_label.visible = false
+    elif not _error_label.text.is_empty():
+        _error_label.visible = true
+
+func _validate(address: String, port_text: String) -> Dictionary:
+    if address.is_empty():
+        return {"ok": false, "error": "Enter an address or room code."}
+    var port_valid := _is_valid_port(port_text)
+    var address_valid := _is_valid_ipv4(address) or _is_valid_hostname(address) or _is_valid_room_code(address)
+    if not port_valid:
+        return {"ok": false, "error": "Port must be between 1 and 65535."}
+    if not address_valid:
+        return {"ok": false, "error": "Use a valid IPv4, hostname, or room code."}
+    return {"ok": true}
+
+func _is_valid_port(value: String) -> bool:
+    if value.is_empty() or not value.is_valid_int():
+        return false
+    var number := int(value)
+    return number > 0 and number < 65536
+
+func _is_valid_ipv4(address: String) -> bool:
+    var segments := address.split(".", false)
+    if segments.size() != 4:
+        return false
+    for segment in segments:
+        if segment.is_empty() or not segment.is_valid_int():
+            return false
+        var number := int(segment)
+        if number < 0 or number > 255:
+            return false
+    return true
+
+func _is_valid_hostname(address: String) -> bool:
+    if address.length() > 253:
+        return false
+    var allowed := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-."
+    for char in address:
+        if not allowed.contains(char):
+            return false
+    if address.begins_with("-") or address.ends_with("-"):
+        return false
+    return true
+
+func _is_valid_room_code(address: String) -> bool:
+    if address.is_empty():
+        return false
+    var upper := address.strip_edges().to_upper()
+    if upper.length() < room_code_min_length or upper.length() > room_code_max_length:
+        return false
+    for char in upper:
+        var is_letter := char >= "A" and char <= "Z"
+        var is_number := char >= "0" and char <= "9"
+        if not (is_letter or is_number):
+            return false
+    return true

--- a/room_sync/ui/ManualJoinPanel.tscn
+++ b/room_sync/ui/ManualJoinPanel.tscn
@@ -1,0 +1,68 @@
+[gd_scene load_steps=2 format=3 uid="uid://manualjoinpanel"]
+
+[ext_resource type="Script" path="res://ui/ManualJoinPanel.gd" id="1_jt8oi"]
+
+[node name="ManualJoinPanel" type="Panel"]
+custom_minimum_size = Vector2(360, 220)
+clip_contents = false
+script = ExtResource("1_jt8oi")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 16.0
+offset_top = 16.0
+offset_right = -16.0
+offset_bottom = -16.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="VBox" type="VBoxContainer" parent="MarginContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 12
+
+[node name="TitleLabel" type="Label" parent="MarginContainer/VBox"]
+text = "Manual Join"
+vertical_alignment = 1
+
+[node name="Instructions" type="Label" parent="MarginContainer/VBox"]
+autowrap_mode = 1
+text = "Enter an IP, hostname, or room code plus the port shared by the room owner."
+
+[node name="AddressLabel" type="Label" parent="MarginContainer/VBox"]
+text = "Address"
+
+[node name="IpLineEdit" type="LineEdit" parent="MarginContainer/VBox"]
+placeholder_text = "192.168.0.24, room.local, or CODE123"
+text = ""
+
+[node name="PortLabel" type="Label" parent="MarginContainer/VBox"]
+text = "Port"
+
+[node name="PortLineEdit" type="LineEdit" parent="MarginContainer/VBox"]
+placeholder_text = "47845"
+virtual_keyboard_type = 2
+text = ""
+
+[node name="ErrorLabel" type="Label" parent="MarginContainer/VBox"]
+visible = false
+modulate = Color(1, 0.356863, 0.356863, 1)
+autowrap_mode = 1
+text = ""
+
+[node name="Buttons" type="HBoxContainer" parent="MarginContainer/VBox"]
+alignment = 2
+
+[node name="CancelButton" type="Button" parent="MarginContainer/VBox/Buttons"]
+text = "Cancel"
+size_flags_horizontal = 1
+
+[node name="JoinButton" type="Button" parent="MarginContainer/VBox/Buttons"]
+text = "Join"
+size_flags_horizontal = 1
+disabled = true


### PR DESCRIPTION
## Summary
- register DiscoveryBeacon, LanRoomManager, and ManualJoinPanel as global classes and enable UDP peer injection for testing
- add a ManualJoinPanel helper for surfacing remote errors and create a headless SceneTree test runner covering LAN discovery, serialization, and join flows
- simulate LAN discovery broadcast edge cases with a mock UDP peer to validate success, multi-host, and blocked scenarios

## Testing
- Not run (Godot CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68deb39ebc3883249799e03b7a7458e3